### PR TITLE
Use static array rather than a vector for errors

### DIFF
--- a/compiler/error.cpp
+++ b/compiler/error.cpp
@@ -1,11 +1,10 @@
 #include "error.h"
 
+
 ErrorSys::ErrorSys()
 {
-	phrases.push_back("empty statement");							// 0
-	phrases.push_back("expected token '%s'");						// 1
-	phrases.push_back("unexpected token '%s'");						// 2
-	phrases.push_back("expected built-in type but got '%s'");		// 3
+	this->fatals = 0;
+	this->warnings = 0;
 }
 
 void ErrorSys::Error(int error, int line, ...)
@@ -16,7 +15,7 @@ void ErrorSys::Error(int error, int line, ...)
 	fatals++;
 
 	char errorstr[128];
-	vsnprintf(errorstr, sizeof(errorstr), phrases[error].c_str(), ap);
+	vsnprintf(errorstr, sizeof(errorstr), this->errors[error], ap);
 
 	char errorstring[256];
 	snprintf(errorstring, sizeof(errorstring), "[Error] [Line %d]: %s", line, errorstr);

--- a/compiler/error.cpp
+++ b/compiler/error.cpp
@@ -15,7 +15,7 @@ void ErrorSys::Error(int error, int line, ...)
 	fatals++;
 
 	char errorstr[128];
-	vsnprintf(errorstr, sizeof(errorstr), this->errors[error], ap);
+	vsnprintf(errorstr, sizeof(errorstr), errors[error], ap);
 
 	char errorstring[256];
 	snprintf(errorstring, sizeof(errorstring), "[Error] [Line %d]: %s", line, errorstr);

--- a/compiler/error.h
+++ b/compiler/error.h
@@ -42,10 +42,15 @@ public:
 	bool Fatal() const;
 
 private:
-	std::vector<std::string> phrases;
 	std::vector<std::string> output;
 	int fatals;
 	int warnings;
+	const char * const errors[] = {
+		/* 00 */	"empty statement",
+		/* 01 */	"expected token '%s'",
+		/* 02 */	"unexpected token '%s'",
+		/* 03 */	"expected built-in type, but got '%s'"
+	};
 };
 
 #endif // H_ERROR

--- a/compiler/error.h
+++ b/compiler/error.h
@@ -6,6 +6,17 @@
 #include "tokenizer.h"
 
 /**
+ * Static list of errors used by ErrorSys to report errors. The index in this
+ * array corresponds with the desired error to be displayed by ErrorSys::Error
+ */
+static const char * const errors[] = {
+	/* 00 */	"empty statement",
+	/* 01 */	"expected token '%s'",
+	/* 02 */	"unexpected token '%s'",
+	/* 03 */	"expected built-in type, but got '%s'"
+};
+
+/**
  * It is the parser's job to make sense of the syntax, and ensure that
  * the grammar of the source programmign language is correct. The parser
  * will also be given a pointer to the errorsys, which handles any syntax
@@ -45,12 +56,6 @@ private:
 	std::vector<std::string> output;
 	int fatals;
 	int warnings;
-	const char * const errors[] = {
-		/* 00 */	"empty statement",
-		/* 01 */	"expected token '%s'",
-		/* 02 */	"unexpected token '%s'",
-		/* 03 */	"expected built-in type, but got '%s'"
-	};
 };
 
 #endif // H_ERROR


### PR DESCRIPTION
Using the vector had good intentions, but any time an error is deleted that isn't in the latest index, it involved shifting all errors throughout the code down one. Using a static array will be faster and save some time later down the road.


Simplicity ftw