### PR TITLE
Add types to function grammar

### DIFF
--- a/compiler/grammar.txt
+++ b/compiler/grammar.txt
@@ -9,7 +9,7 @@ declaration ::= builtin_type <identifier>
 statement_list ::= {statement} ';' {statement_list}
 				| {statement}
 
-function ::= 'func' <identifier> '(' ')' '{' {statement_list} '}'
+function ::= 'func' <builtin_type> <identifier> '(' ')' '{' {statement_list} '}'
 
 native ::= 'native' <identifier> '(' {param_list} ')' ';'
 

--- a/compiler/parser.cpp
+++ b/compiler/parser.cpp
@@ -181,6 +181,12 @@ void Parser::DoFunction()
 	printf("Falling into function parse\n");
 #endif
 
+	Token *ret;
+	if ((ret = tokenizer->Match(tINT)) == nullptr) {
+		errorsys->Error(1, func->line, "<return type>"); // 
+		return;
+	}
+
 	Token *ident;
 	if ((ident = tokenizer->Match(tIDENT)) == nullptr) {
 		errorsys->Error(1, func->line, "<identifier>"); // expected token <identifier>

--- a/compiler/tests/fail-expected-token-(.x
+++ b/compiler/tests/fail-expected-token-(.x
@@ -1,4 +1,4 @@
-func main)
+func int main)
 {
 	int a;
 	a = 4;

--- a/compiler/tests/fail-expected-token-ret.txt
+++ b/compiler/tests/fail-expected-token-ret.txt
@@ -1,0 +1,1 @@
+[Error] [Line 1]: expected token '<return type>'

--- a/compiler/tests/fail-expected-token-ret.x
+++ b/compiler/tests/fail-expected-token-ret.x
@@ -1,4 +1,5 @@
-func int main()
+func main(
+{
 	int a;
 	a = 4;
 }

--- a/compiler/tests/fail-expected-token-}.x
+++ b/compiler/tests/fail-expected-token-}.x
@@ -1,4 +1,4 @@
-func main()
+func int main()
 {
 	int a;
 	a = 4;

--- a/compiler/tests/fail-unexpected-token-{.x
+++ b/compiler/tests/fail-unexpected-token-{.x
@@ -1,4 +1,4 @@
-func main(
+func int main(
 {
 	int a;
 	a = 4;

--- a/compiler/tests/ok-args-parse-many.x
+++ b/compiler/tests/ok-args-parse-many.x
@@ -1,4 +1,4 @@
-func somefunction(int arg1, int arg2, int arg3, int arg4, int arg5)
+func int somefunction(int arg1, int arg2, int arg3, int arg4, int arg5)
 {
 	int a;
 	a = 4;

--- a/compiler/tests/ok-args-parse.x
+++ b/compiler/tests/ok-args-parse.x
@@ -1,4 +1,4 @@
-func somefunction(int arg1, int arg2)
+func int somefunction(int arg1, int arg2)
 {
 	int a;
 	a = 4;

--- a/compiler/tests/ok-function-call.x
+++ b/compiler/tests/ok-function-call.x
@@ -1,4 +1,4 @@
-func somefunction()
+func int somefunction()
 {
 	int a;
 	a = 4;

--- a/compiler/tests/ok-global-var.x
+++ b/compiler/tests/ok-global-var.x
@@ -1,6 +1,6 @@
 int a;
 
-func main()
+func int main()
 {
 	a = 4;
 }

--- a/compiler/tests/ok-native-declaration.x
+++ b/compiler/tests/ok-native-declaration.x
@@ -1,6 +1,6 @@
 native somenative(int arg1, int arg2, int arg3, int arg4, int arg5);
 
-func main()
+func int main()
 {
 	int a;
 	a = 4;

--- a/compiler/tests/ok-spacing.x
+++ b/compiler/tests/ok-spacing.x
@@ -1,4 +1,4 @@
-func main
+func int main
 
 (
 


### PR DESCRIPTION
Before this change, function return types were to be assumed. I realize now, though, that for this language to be simple to understand and work in we need to cut out assumptions and do less magic on our end. This is also easier when other types come into play, but for now `int` is our go-to.